### PR TITLE
Fix tsconfig

### DIFF
--- a/app/boot.ts
+++ b/app/boot.ts
@@ -1,3 +1,5 @@
+///<reference path="../node_modules/angular2/typings/browser.d.ts"/>
+
 import {bootstrap} from 'angular2/platform/browser';
 import {ROUTER_PROVIDERS} from 'angular2/router';
 import {AppComponent} from './app.component';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
   },
   "exclude": [
     "node_modules",
-    "typings/main",
-    "typings/main.d.ts"
+    "typings/browser",
+    "typings/browser.d.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,6 @@
     "removeComments": false,
     "noImplicitAny": false
   },
-  "files": [
-    "typings/main.d.ts"
-  ],
   "exclude": [
     "node_modules",
     "typings/main",


### PR DESCRIPTION
- fix an issue where `tsc` compiles nothing due to `files` key defined in *tsconfig.json* (will only compile all inside `files`), removing this key will compile everything but in `exclude` key. 
I just realized this issue when my sublime typescript plugin stop working
- exclude *browser.d.ts* typings
- use reference path in *boot.ts* so that `tsc` can compile without typing error, currently it's a success with `gulp tsc`, but not with `tsc`