### PR TITLE
Appveyor build (fails on IE 11)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+# AppVeyor file
+# http://www.appveyor.com/docs/appveyor-yml
+# This file: cloned from https://github.com/gruntjs/grunt/blob/master/appveyor.yml
+
+# Build version format
+version: "{build}"
+
+# Test against this version of Node.js
+environment:
+  nodejs_version: "5.5.0"
+
+build: off
+
+clone_depth: 10
+
+# Fix line endings on Windows
+init:
+  - git config --global core.autocrlf true
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install -g npm
+  - ps: $env:path = $env:appdata + "\npm;" + $env:path
+  - npm install
+
+test_script:
+  # Output useful info for debugging.
+  - node --version && npm --version
+  - node -e 'console.log(process.env);'
+  # We test multiple Windows shells because of prior stdout buffering issues
+  # filed against Grunt. https://github.com/joyent/node/issues/3584
+  - ps: "npm test # PowerShell" # Pass comment to PS for easier debugging
+  - cmd: npm test
+
+cache:
+  - node_modules -> package.json                                        # local npm modules

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,8 +19,13 @@ module.exports = function(config) {
       ]
     },
 
-    files: [      
+    files: [
       'node_modules/traceur/bin/traceur-runtime.js',
+      //<!-- IE required polyfills, in this exact order -->
+      'node_modules/es6-shim/es6-shim.min.js',
+      'node_modules/systemjs/dist/system-polyfills.js',
+      'node_modules/angular2/es6/dev/src/testing/shims_for_IE.js',
+
       'node_modules/angular2/bundles/angular2-polyfills.js',
       // 'node_modules/zone.js/dist/zone-microtask.js',
       // 'node_modules/zone.js/dist/long-stack-trace-zone.js',
@@ -33,7 +38,6 @@ module.exports = function(config) {
       { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
       { pattern: 'app/**/*.js', included: false, watched: true },
       { pattern: 'test/test-helpers/*.js', included: false, watched: true },
-      { pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: false, watched: false },
 
       // paths loaded via Angular's component compiler
       // (these paths need to be rewritten, see proxies section)
@@ -55,8 +59,14 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
-    singleRun: true
+    singleRun: true,
   };
+
+  if (process.env.APPVEYOR) {
+    configuration.browsers = ['IE'];
+    configuration.singleRun = true;
+    configuration.browserNoActivityTimeout = 90000; // Note: default value (10000) is not enough
+  }
 
   config.set(configuration);
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "jasmine-core": "~2.4.1",
     "karma": "~0.13.21",
     "karma-coverage": "~0.5.3",
+    "karma-ie-launcher": "^0.2.0",
     "karma-jasmine": "~0.3.7",
     "karma-phantomjs-launcher": "~1.0.0",
     "karma-sourcemap-loader": "^0.3.7",


### PR DESCRIPTION
@antonybudianto I wanted to see if your starter project works on IE. 

This PR shows an error when running the unit tests on IE

See https://ci.appveyor.com/project/jesperronn/angular2-starter/build/6#L997

I am probably missing an IE specific shim or something. Any suggestions?


PS (please don't merge this – at least not until it works )