### PR TITLE
Regular deps update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: node_js
 node_js:
   - "5.6"
   - "4.3"
-  - "0.12.10"
 script: gulp build
 after_script:
   - npm run-script coveralls

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Please visit the [wiki](https://github.com/antonybudianto/angular2-starter/wiki)
 
 ## Installation
 Firstly, you need to have [Node.js](https://nodejs.org/en/) 
-- Support from v0.12.10 (LTS) or higher 
 - For v4, please use v4.3.x (LTS) or higher (**highly** recommended)
 - For v5, please use v5.6.x or higher, here is [why](https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-starter",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "author": "Antony Budianto",
   "description": "Angular 2 Starter with Gulp, Bower, Karma, Jasmine, Protractor using SystemJS",
   "main": "index.html",
@@ -31,13 +31,13 @@
     "url": "https://github.com/antonybudianto/angular2-starter/issues"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.9",
+    "angular2": "2.0.0-beta.11",
     "systemjs": "^0.19.24",
     "es6-promise": "^3.1.2",
-    "es6-shim": "^0.33.3",
+    "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",
-    "zone.js": "0.5.15"
+    "zone.js": "^0.6.4"
   },
   "devDependencies": {
     "coveralls": "^2.11.8",
@@ -46,8 +46,8 @@
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.1",
     "gulp-if": "~2.0.0",
-    "gulp-inject": "^3.0.0",
-    "gulp-protractor": "^2.1.0",
+    "gulp-inject": "^4.0.0",
+    "gulp-protractor": "^2.2.0",
     "gulp-rev": "^7.0.0",
     "gulp-rev-replace": "^0.4.3",
     "gulp-sass": "^2.2.0",
@@ -60,19 +60,19 @@
     "karma": "~0.13.22",
     "karma-coverage": "~0.5.5",
     "karma-ie-launcher": "^0.2.0",
-    "karma-jasmine": "~0.3.7",
+    "karma-jasmine": "~0.3.8",
     "karma-phantomjs-launcher": "~1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "live-server": "~0.9.2",
     "main-bower-files": "^2.11.1",
     "path": "^0.12.7",
-    "phantomjs-prebuilt": "^2.1.5",
+    "phantomjs-prebuilt": "^2.1.6",
     "remap-istanbul": "~0.5.1",
     "require-dir": "~0.3.0",
     "run-sequence": "^1.1.5",
-    "systemjs-builder": "~0.15.12",
+    "systemjs-builder": "~0.15.13",
     "traceur": "~0.0.104",
-    "tslint": "^3.5.0",
-    "typings": "^0.7.7"
+    "tslint": "^3.6.0",
+    "typings": "^0.7.9"
   }
 }


### PR DESCRIPTION
Angular 2 Beta 11, Gulp inject 4, and others
> Now dropping support for node `0.x.x` since gulp inject 4 needs `4.x.x` and `4.3.x` is recommended since known security updates