### PR TITLE
Walk around for issue #76; Safari issue with serve-build.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,12 +21,12 @@
     <script src="node_modules/bootstrap-sass/assets/javascripts/bootstrap.js"></script>
 
     <!-- 1. Load libraries -->
-    <!-- Polyfill(s) for older browsers -->
-    <script src="node_modules/es6-shim/es6-shim.min.js"></script>
-
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
     <script src="node_modules/systemjs/dist/system.js"></script>
+
+    <!-- Polyfill(s) for older browsers -->
+    <script src="node_modules/es6-shim/es6-shim.min.js"></script>
     <!-- endbuild -->
 
     <!-- build:remove -->


### PR DESCRIPTION
@antonybudianto I'm happy to PR for the issue #76.

Changing `es6-shim.min.js` to `es6-shim.js` was not necessary.
What I've done is moving es6-shim to the end of `bundle.js`.
Don't know why but it's interesting.

**Edit by antony**
fix #76 