### PR TITLE
fix #172

### DIFF
--- a/config/gulp/tasks/build.js
+++ b/config/gulp/tasks/build.js
@@ -28,7 +28,7 @@ gulp.task('build-assets', function (done) {
         gulp.src(config.app + '**/*.css', {
             base: config.app
         })
-        .pipe(cssnano())
+        .pipe(cssnano({zindex: false}))
         .pipe(gulp.dest(config.build.app));
 
         gulp.src(config.src + 'favicon.ico')


### PR DESCRIPTION
I have noted that when issuing a gulp build and minifying the css with the gulp-cssnano plugin the z-index where modified sometimes. In my case from 5 to 2. To avpid modifications of the z-index I provided this solution.

cheers